### PR TITLE
Implement prototype server and SQL schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+web_images/
+pod_images/
+app.db
+image_mapping.csv
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
-# test
-test
+# Character Customization Prototype
+
+This repository contains a minimal prototype for a character customization service.
+The `app.py` server exposes simple endpoints for listing packages, purchasing
+items with points, and uploading images. Uploaded images are saved in two
+directories:
+
+* `web_images/` – optimized WebP images used for the UI
+* `pod_images/` – high‑resolution originals for POD printing
+
+The database schema is defined in `schema.sql` and implemented via SQLAlchemy in
+`app.py`.
+
+## Quick Start
+
+```bash
+pip install flask sqlalchemy pillow
+python app.py
+```
+
+The server starts on `http://localhost:5000`.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,114 @@
+from flask import Flask, jsonify, request
+from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy import CheckConstraint
+import uuid
+
+app = Flask(__name__)
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///app.db'
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+
+db = SQLAlchemy(app)
+
+# Models
+class User(db.Model):
+    __tablename__ = 'users'
+    id = db.Column(db.Integer, primary_key=True)
+    point_balance = db.Column(db.Integer, nullable=False, default=0)
+
+class Character(db.Model):
+    __tablename__ = 'characters'
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(100), nullable=False)
+    intro = db.Column(db.Text)
+
+class UserCharacter(db.Model):
+    __tablename__ = 'user_characters'
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False)
+    character_id = db.Column(db.Integer, db.ForeignKey('characters.id'), nullable=False)
+
+class Package(db.Model):
+    __tablename__ = 'packages'
+    id = db.Column(db.Integer, primary_key=True)
+    character_id = db.Column(db.Integer, db.ForeignKey('characters.id'), nullable=False)
+    name = db.Column(db.String(150), nullable=False)
+    thumbnail_url = db.Column(db.String(500), nullable=False)
+    description = db.Column(db.Text)
+    status = db.Column(db.String(20), nullable=False, default='심사대기')
+
+class PatchGroup(db.Model):
+    __tablename__ = 'patch_groups'
+    id = db.Column(db.Integer, primary_key=True)
+    character_id = db.Column(db.Integer, db.ForeignKey('characters.id'), nullable=False)
+    name = db.Column(db.String(50), nullable=False)
+
+class Item(db.Model):
+    __tablename__ = 'items'
+    id = db.Column(db.Integer, primary_key=True)
+    package_id = db.Column(db.Integer, db.ForeignKey('packages.id'), nullable=False)
+    patch_group_id = db.Column(db.Integer, db.ForeignKey('patch_groups.id'), nullable=False)
+    name = db.Column(db.String(100), nullable=False)
+    price = db.Column(db.Integer, nullable=False, default=50)
+    meta_data = db.Column(db.JSON)
+    original_image_url = db.Column(db.String(500), nullable=False)
+    web_image_url = db.Column(db.String(500), nullable=False)
+    is_default = db.Column(db.Boolean, nullable=False, default=False)
+    __table_args__ = (
+        db.UniqueConstraint('package_id', 'patch_group_id', 'is_default', name='uix_default'),
+    )
+
+class UserCharacterCustomization(db.Model):
+    __tablename__ = 'user_character_customizations'
+    user_character_id = db.Column(db.Integer, db.ForeignKey('user_characters.id'), primary_key=True)
+    patch_group_id = db.Column(db.Integer, db.ForeignKey('patch_groups.id'), primary_key=True)
+    item_id = db.Column(db.Integer, db.ForeignKey('items.id'), nullable=False)
+
+with app.app_context():
+    db.create_all()
+    if not User.query.first():
+        user = User(point_balance=1000)
+        db.session.add(user)
+        db.session.commit()
+    import os
+    os.makedirs('web_images', exist_ok=True)
+    os.makedirs('pod_images', exist_ok=True)
+
+# Routes
+@app.route('/packages')
+def list_packages():
+    packages = Package.query.all()
+    data = []
+    for p in packages:
+        data.append({'id': p.id, 'name': p.name, 'status': p.status, 'thumbnail': p.thumbnail_url})
+    return jsonify(data)
+
+@app.route('/purchase', methods=['POST'])
+def purchase_item():
+    data = request.json
+    user = User.query.get(data['user_id'])
+    item = Item.query.get(data['item_id'])
+    if not user or not item:
+        return jsonify({'error': 'Invalid user or item'}), 400
+    if user.point_balance < item.price:
+        return jsonify({'error': 'Not enough points'}), 400
+    user.point_balance -= item.price
+    db.session.commit()
+    return jsonify({'message': 'purchased'})
+
+@app.route('/upload-image', methods=['POST'])
+def upload_image():
+    file = request.files['image']
+    uid = str(uuid.uuid4())
+    import os
+    os.makedirs('web_images', exist_ok=True)
+    os.makedirs('pod_images', exist_ok=True)
+    web_path = os.path.join('web_images', f'{uid}.webp')
+    pod_path = os.path.join('pod_images', f'{uid}{file.filename[file.filename.rfind("."):]}' )
+    from PIL import Image
+    img = Image.open(file.stream)
+    img.save(pod_path)
+    img.save(web_path, format='WEBP', quality=85)
+    return jsonify({'web_url': web_path, 'original_url': pod_path})
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/process_images.py
+++ b/process_images.py
@@ -1,0 +1,29 @@
+import os
+import uuid
+from PIL import Image
+
+SOURCE_DIR = 'image_data'
+WEB_DIR = 'web_images'
+POD_DIR = 'pod_images'
+
+os.makedirs(WEB_DIR, exist_ok=True)
+os.makedirs(POD_DIR, exist_ok=True)
+
+mapping = []
+
+for root, _, files in os.walk(SOURCE_DIR):
+    for fname in files:
+        if not fname.lower().endswith(('.png', '.jpg', '.jpeg', '.webp')):
+            continue
+        path = os.path.join(root, fname)
+        uid = str(uuid.uuid4())
+        img = Image.open(path)
+        pod_path = os.path.join(POD_DIR, f'{uid}{os.path.splitext(fname)[1]}')
+        img.save(pod_path)
+        web_path = os.path.join(WEB_DIR, f'{uid}.webp')
+        img.save(web_path, format='WEBP', quality=85)
+        mapping.append(f'{path},{pod_path},{web_path}\n')
+
+with open('image_mapping.csv', 'w') as f:
+    f.writelines(mapping)
+print(f'Processed {len(mapping)} images.')

--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,53 @@
+-- SQL schema implementing db.md
+
+CREATE TABLE users (
+    id SERIAL PRIMARY KEY,
+    point_balance INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE characters (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    intro TEXT
+);
+
+CREATE TABLE user_characters (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER NOT NULL REFERENCES users(id),
+    character_id INTEGER NOT NULL REFERENCES characters(id)
+);
+
+CREATE TABLE packages (
+    id SERIAL PRIMARY KEY,
+    character_id INTEGER NOT NULL REFERENCES characters(id),
+    name VARCHAR(150) NOT NULL,
+    thumbnail_url VARCHAR(500) NOT NULL,
+    description TEXT
+);
+
+CREATE TABLE patch_groups (
+    id SERIAL PRIMARY KEY,
+    character_id INTEGER NOT NULL REFERENCES characters(id),
+    name VARCHAR(50) NOT NULL
+);
+
+CREATE TABLE items (
+    id SERIAL PRIMARY KEY,
+    package_id INTEGER NOT NULL REFERENCES packages(id),
+    patch_group_id INTEGER NOT NULL REFERENCES patch_groups(id),
+    name VARCHAR(100) NOT NULL,
+    price INTEGER NOT NULL DEFAULT 50,
+    metadata JSON,
+    original_image_url VARCHAR(500) NOT NULL,
+    web_image_url VARCHAR(500) NOT NULL,
+    is_default BOOLEAN NOT NULL DEFAULT FALSE,
+    UNIQUE (package_id, patch_group_id, is_default)
+);
+
+CREATE TABLE user_character_customizations (
+    user_character_id INTEGER NOT NULL REFERENCES user_characters(id),
+    patch_group_id INTEGER NOT NULL REFERENCES patch_groups(id),
+    item_id INTEGER NOT NULL REFERENCES items(id),
+    PRIMARY KEY (user_character_id, patch_group_id),
+    FOREIGN KEY (patch_group_id, item_id) REFERENCES items(patch_group_id, id)
+);


### PR DESCRIPTION
## Summary
- add minimal Flask server with SQLAlchemy models
- include upload and purchase endpoints
- include image processing helper
- document setup in README
- provide SQL schema for DB

## Testing
- `python process_images.py` processed 102 sample images
- `python app.py` launches server without errors

------
https://chatgpt.com/codex/tasks/task_e_6864c5d9e2388323842d5dd2ad4cfb88