### PR TITLE
Fix React optional chaining issue on user page

### DIFF
--- a/frontend/user.html
+++ b/frontend/user.html
@@ -133,7 +133,12 @@
               <h4>{group.name}</h4>
               <div className="item-list">
                 {items.map(it => (
-                  <img key={it.id} src={it.web_image_url} style={{border: selection[group.id]?.id===it.id?'2px solid blue':'1px solid #ccc'}} onClick={() => select(it)} />
+                  <img
+                    key={it.id}
+                    src={it.web_image_url}
+                    style={{border: (selection[group.id] && selection[group.id].id === it.id) ? '2px solid blue' : '1px solid #ccc'}}
+                    onClick={() => select(it)}
+                  />
                 ))}
               </div>
             </div>


### PR DESCRIPTION
## Summary
- remove optional chaining from user page so Babel 6 can parse

## Testing
- `npm test` (fails as no tests are defined)

------
https://chatgpt.com/codex/tasks/task_e_6864d57e39dc83238e9f4a0db1a7b9b2